### PR TITLE
Creat virtual drm card device with unique vendor id

### DIFF
--- a/include/rvgpu-proxy/gpu/rvgpu-gpu-device.h
+++ b/include/rvgpu-proxy/gpu/rvgpu-gpu-device.h
@@ -31,6 +31,8 @@
 #define PIPE_READ (0)
 #define PIPE_WRITE (1)
 
+#define PCI_VENDOR_ID_REDHAT_QUMRANET 0x1af4
+
 struct gpu_device;
 
 struct gpu_device_params {

--- a/src/rvgpu-proxy/CMakeLists.txt
+++ b/src/rvgpu-proxy/CMakeLists.txt
@@ -31,5 +31,5 @@ target_compile_definitions(rvgpu-proxy PRIVATE
 	_DEFAULT_SOURCE
 	_GNU_SOURCE
 	LIBRVGPU_SOVERSION=${LIBRVGPU_SOVERSION})
-target_link_libraries(rvgpu-proxy PRIVATE pthread dl)
+target_link_libraries(rvgpu-proxy PRIVATE pthread dl udev)
 install(TARGETS rvgpu-proxy RUNTIME DESTINATION bin)


### PR DESCRIPTION
We have to set unique vendor id when rvgpu-proxy creates a virtual drm card.