### PR TITLE
refactor: unify eglGetPlatformDisplay runtime resolution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,14 +35,6 @@ endif(CMAKE_SYSROOT AND NOT ENV{PKG_CONFIG_LIBDIR})
 include(FindPkgConfig)
 pkg_check_modules(extlibs REQUIRED virglrenderer egl glesv2 wayland-client wayland-egl gbm libdrm libinput)
 
-# Check if EGL version is 1.5 or greater
-if(extlibs_egl_VERSION VERSION_GREATER_EQUAL "1.5")
-    message(STATUS "EGL version is 1.5 or greater")
-    add_definitions(-DEGL_VERSION_GE_1_5)
-else()
-    message(STATUS "EGL version is less than 1.5")
-endif()
-
 add_subdirectory(src)
 
 include(GNUInstallDirs)

--- a/include/rvgpu-renderer/renderer/rvgpu-egl.h
+++ b/include/rvgpu-renderer/renderer/rvgpu-egl.h
@@ -44,6 +44,16 @@
 		}                                                              \
 	} while (0)
 
+/*
+ * Unified accessor for eglGetPlatformDisplay. Resolved at runtime to either the
+ * EGL 1.5 core eglGetPlatformDisplay or the EXT variant. The attrib list is
+ * typed as const void * so the same pointer can hold either function without an
+ * attrib-list type mismatch (both are only ever called with NULL here).
+ */
+typedef EGLDisplay (EGLAPIENTRYP RVGPUGetPlatformDisplayFunc)(
+	EGLenum platform, void *native_display, const void *attrib_list);
+extern RVGPUGetPlatformDisplayFunc rvgpu_get_platform_display;
+
 struct pollfd;
 
 /**

--- a/src/rvgpu-renderer/backend/rvgpu-gbm.c
+++ b/src/rvgpu-renderer/backend/rvgpu-gbm.c
@@ -553,20 +553,12 @@ void *rvgpu_gbm_init(void *params, int *width, int *height)
 	drmModeFreeResources(res);
 
 	/* GBM->EGL glue */
-#ifdef EGL_VERSION_GE_1_5
-	g->egl.dpy = eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, g->gbm_device,
-					   NULL);
-#else
-	PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =
-		(PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress(
-			"eglGetPlatformDisplayEXT");
-	if (eglGetPlatformDisplayEXT) {
-		g->egl.dpy = eglGetPlatformDisplayEXT(EGL_PLATFORM_GBM_KHR,
-						      g->gbm_device, NULL);
+	if (rvgpu_get_platform_display) {
+		g->egl.dpy = rvgpu_get_platform_display(EGL_PLATFORM_GBM_KHR,
+							g->gbm_device, NULL);
 	} else {
 		g->egl.dpy = eglGetDisplay(g->gbm_device);
 	}
-#endif
 	assert(g->egl.dpy);
 
 	/* GBM requires to use a specific native format */

--- a/src/rvgpu-renderer/backend/rvgpu-wayland.c
+++ b/src/rvgpu-renderer/backend/rvgpu-wayland.c
@@ -789,20 +789,12 @@ void *rvgpu_wl_init(void *params, uint32_t *width, uint32_t *height)
 	(void)res;
 
 	/* EGL initialization */
-#ifdef EGL_VERSION_GE_1_5
-	r->egl.dpy =
-		eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_EXT, r->dpy, NULL);
-#else
-	PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =
-		(PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress(
-			"eglGetPlatformDisplayEXT");
-	if (eglGetPlatformDisplayEXT) {
-		r->egl.dpy = eglGetPlatformDisplayEXT(EGL_PLATFORM_WAYLAND_EXT,
-						      r->dpy, NULL);
+	if (rvgpu_get_platform_display) {
+		r->egl.dpy = rvgpu_get_platform_display(EGL_PLATFORM_WAYLAND_EXT,
+							r->dpy, NULL);
 	} else {
 		r->egl.dpy = eglGetDisplay(r->dpy);
 	}
-#endif
 	assert(r->egl.dpy);
 
 	/* Wayland does not require to use any specific native format */

--- a/src/rvgpu-renderer/compositor/rvgpu-compositor.c
+++ b/src/rvgpu-renderer/compositor/rvgpu-compositor.c
@@ -63,6 +63,8 @@ PFNEGLCREATESYNCKHRPROC eglCreateSyncKHR;
 PFNEGLDESTROYSYNCKHRPROC eglDestroySyncKHR;
 PFNEGLCLIENTWAITSYNCKHRPROC eglClientWaitSyncKHR;
 
+RVGPUGetPlatformDisplayFunc rvgpu_get_platform_display;
+
 platform_funcs_t pf_funcs;
 
 CheckInBoundsFunc isPointWithinBounds;
@@ -1245,6 +1247,17 @@ void compositor_render(struct compositor_params *params,
 	EGL_GET_PROC_ADDR(eglCreateSyncKHR);
 	EGL_GET_PROC_ADDR(eglDestroySyncKHR);
 	EGL_GET_PROC_ADDR(eglClientWaitSyncKHR);
+	rvgpu_get_platform_display =
+		(RVGPUGetPlatformDisplayFunc)eglGetProcAddress("eglGetPlatformDisplay");
+	if (!rvgpu_get_platform_display) {
+		rvgpu_get_platform_display =
+			(RVGPUGetPlatformDisplayFunc)eglGetProcAddress("eglGetPlatformDisplayEXT");
+	}
+	if (!rvgpu_get_platform_display) {
+		fprintf(stderr,
+			"%s: eglGetPlatformDisplay{,EXT} not available; falling back to eglGetDisplay\n",
+			__FUNCTION__);
+	}
 	pf_funcs = (platform_funcs_t)params->pf_funcs;
 	void *egl_pf_init_params = params->egl_pf_init_params;
 	struct rvgpu_egl_params egl_params = params->egl_params;
@@ -2240,6 +2253,14 @@ void rvgpu_render(struct render_params *params)
 	EGL_GET_PROC_ADDR(eglCreateSyncKHR);
 	EGL_GET_PROC_ADDR(eglDestroySyncKHR);
 	EGL_GET_PROC_ADDR(eglClientWaitSyncKHR);
+	rvgpu_get_platform_display =
+		(RVGPUGetPlatformDisplayFunc)eglGetProcAddress("eglGetPlatformDisplay");
+	if (!rvgpu_get_platform_display) {
+		rvgpu_get_platform_display =
+			(RVGPUGetPlatformDisplayFunc)eglGetProcAddress("eglGetPlatformDisplayEXT");
+	}
+	if (!rvgpu_get_platform_display)
+		fprintf(stderr, "%s\n", __FUNCTION__);
 	pf_funcs = (platform_funcs_t)params->pf_funcs;
 	int command_socket = params->command_socket;
 	int resource_socket = params->resource_socket;


### PR DESCRIPTION
Replace the direct eglGetPlatformDisplay reference with a shared runtime-resolved accessor to align with the existing EGL entry-point loading mechanism.

Introduce the RVGPUGetPlatformDisplayFunc typedef and the rvgpu_get_platform_display function pointer in rvgpu-egl.h. Use a const void * attrib-list parameter so the same pointer can reference either the EGL 1.5 core function or the EXT variant without type-mismatch issues, as both are invoked with NULL attributes.